### PR TITLE
Add the option in the action to take square screenshots and also wait for the page load completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run screenshot monitoring
-        uses: guibranco/github-screenshot-action@v2.0.9
+        uses: guibranco/github-screenshot-action@v2.0.17
         with:
           json_file: "sites.json"
           output_dir: "screenshots/"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A reusable GitHub Action that takes screenshots of websites from a JSON list, wi
 | 🔀 **Automated PRs** | Optionally open a pull request automatically after each monitoring run |
 | 🐳 **Pre-built Docker image** | No cold build — uses a pre-published image from GHCR for fast startup |
 | 🔐 **Chromium-based** | Full Puppeteer + Chromium stack for accurate, real-browser rendering |
+| ⏳ **Wait strategies** | Wait for full page load, network idle, or DOM ready before capturing |
+| 🟥 **Square mode** | Optionally clip output to a square for thumbnails or social previews |
 
 ---
 
@@ -73,6 +75,9 @@ jobs:
           timeout_ms: "20000"
           create_pr: "true"
           branch_name: "monitor/screenshots"
+          wait_until: "networkidle0"
+          square: "false"
+          viewport_width: "1280"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -90,6 +95,9 @@ jobs:
 | `timeout_ms` | ❌ | `30000` | Page load timeout per site in milliseconds |
 | `create_pr` | ❌ | `false` | If `true`, opens a PR after committing screenshots |
 | `branch_name` | ❌ | `monitor/screenshots` | Branch to commit screenshots to |
+| `wait_until` | ❌ | `load` | Page load event to wait for before capturing. See [Wait Strategies](#wait-strategies) |
+| `square` | ❌ | `false` | If `true`, clips the output to a square using `viewport_width` as the side length |
+| `viewport_width` | ❌ | `1280` | Viewport width in pixels. Also controls the square size when `square` is `true` |
 
 ---
 
@@ -134,6 +142,36 @@ env:
 
 ---
 
+## ⏳ Wait Strategies
+
+The `wait_until` input controls when Puppeteer considers the page ready to capture. Choose based on how dynamic the target site is:
+
+| Value | Waits until... | Best for |
+|---|---|---|
+| `domcontentloaded` | HTML is parsed, no assets waited on | Simple static pages |
+| `load` | All resources loaded (default) | Most standard websites |
+| `networkidle2` | No more than 2 requests in flight for 500ms | Pages with background polling |
+| `networkidle0` | Zero network requests for 500ms | SPAs and lazy-loaded content |
+
+> **Tip:** `networkidle0` produces the most complete captures but is the slowest. If a site has continuous background requests (analytics, websockets), use `networkidle2` to avoid hitting the timeout.
+
+---
+
+## 🟥 Square Mode
+
+When `square: "true"`, the action sets a square viewport and clips the output to `viewport_width × viewport_width` pixels. Full-page scrolling is disabled in this mode.
+
+```yaml
+square: "true"
+viewport_width: "1280"  # produces a 1280×1280 PNG
+```
+
+This is useful for generating consistent thumbnails, social preview images, or monitoring dashboards where uniform dimensions are required.
+
+> **Note:** `square` and full-page capture are mutually exclusive. When `square` is enabled, only the top portion of the page visible within the square viewport is captured.
+
+---
+
 ## 🗓️ Scheduling Examples
 
 ```yaml
@@ -163,7 +201,9 @@ parser.ts ──► loadItems()
                     ▼
             screenshot.ts ──► Puppeteer + pLimit (parallel)
                     │              │
-                    │         Chromium (headless)
+                    │         setViewport(width, height)
+                    │         goto(url, { waitUntil })
+                    │         screenshot({ fullPage | clip })
                     │
                     ▼
               output_dir/*.png

--- a/__tests__/screenshot.test.ts
+++ b/__tests__/screenshot.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import puppeteer from "puppeteer";
 import { takeScreenshots } from "../src/screenshot";
 
-// ── mock fs ──────────────────────────────────────────────────────────────────
+// ── mock fs ───────────────────────────────────────────────────────────────────
 jest.mock("fs", () => ({
   ...jest.requireActual("fs"),
   existsSync: jest.fn().mockReturnValue(true),
@@ -10,25 +10,42 @@ jest.mock("fs", () => ({
   writeFileSync: jest.fn(),
 }));
 
-// ── mock puppeteer ────────────────────────────────────────────────────────────
-const mockClose     = jest.fn();
-const mockScreenshot = jest.fn().mockResolvedValue(Buffer.from("png-data"));
-const mockGoto      = jest.fn();
-const mockSetViewport = jest.fn();
-const mockPageClose = jest.fn();
-const mockNewPage   = jest.fn().mockResolvedValue({
-  setViewport: mockSetViewport,
-  goto: mockGoto,
-  screenshot: mockScreenshot,
-  close: mockPageClose,
+// ── mock puppeteer (all fns defined inside factory to avoid hoisting issues) ──
+jest.mock("puppeteer", () => {
+  const mockPageClose  = jest.fn();
+  const mockScreenshot = jest.fn().mockResolvedValue(Buffer.from("png-data"));
+  const mockGoto       = jest.fn();
+  const mockSetViewport = jest.fn();
+  const mockNewPage    = jest.fn().mockResolvedValue({
+    setViewport: mockSetViewport,
+    goto: mockGoto,
+    screenshot: mockScreenshot,
+    close: mockPageClose,
+  });
+  const mockBrowserClose = jest.fn();
+
+  return {
+    launch: jest.fn().mockResolvedValue({
+      newPage: mockNewPage,
+      close: mockBrowserClose,
+    }),
+  };
 });
 
-jest.mock("puppeteer", () => ({
-  launch: jest.fn().mockResolvedValue({
-    newPage: mockNewPage,
-    close: mockClose,
-  }),
-}));
+// ── helpers to access mocks after hoisting ────────────────────────────────────
+const getMocks = async () => {
+  const browser = await (puppeteer.launch as jest.Mock)();
+  const page    = await browser.newPage();
+  return {
+    launch:      puppeteer.launch as jest.Mock,
+    browserClose: browser.close as jest.Mock,
+    newPage:     browser.newPage as jest.Mock,
+    setViewport: page.setViewport as jest.Mock,
+    goto:        page.goto as jest.Mock,
+    screenshot:  page.screenshot as jest.Mock,
+    pageClose:   page.close as jest.Mock,
+  };
+};
 
 // ── shared base options ───────────────────────────────────────────────────────
 const baseOptions = {
@@ -45,57 +62,64 @@ beforeEach(() => jest.clearAllMocks());
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 test("captures a screenshot with default options", async () => {
+  const { setViewport, goto, screenshot } = await getMocks();
+
   await takeScreenshots([{ url: "https://example.com", name: "homepage" }], "./out", baseOptions);
 
-  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 720 });
-  expect(mockGoto).toHaveBeenCalledWith("https://example.com", {
+  expect(setViewport).toHaveBeenCalledWith({ width: 1280, height: 720 });
+  expect(goto).toHaveBeenCalledWith("https://example.com", {
     timeout: 5000,
     waitUntil: "load",
   });
-  expect(mockScreenshot).toHaveBeenCalledWith({ fullPage: true });
+  expect(screenshot).toHaveBeenCalledWith({ fullPage: true });
   expect(fs.writeFileSync).toHaveBeenCalledWith("out/homepage.png", expect.any(Buffer));
-  expect(mockPageClose).toHaveBeenCalled();
-  expect(mockClose).toHaveBeenCalled();
 });
 
 test("sets square viewport and clip when square is true", async () => {
+  const { setViewport, screenshot } = await getMocks();
+
   await takeScreenshots(
     [{ url: "https://example.com", name: "square-shot" }],
     "./out",
     { ...baseOptions, square: true, viewportWidth: 1280 }
   );
 
-  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 1280 });
-  expect(mockScreenshot).toHaveBeenCalledWith({
+  expect(setViewport).toHaveBeenCalledWith({ width: 1280, height: 1280 });
+  expect(screenshot).toHaveBeenCalledWith({
     fullPage: false,
     clip: { x: 0, y: 0, width: 1280, height: 1280 },
   });
 });
 
 test("passes waitUntil to page.goto", async () => {
+  const { goto } = await getMocks();
+
   await takeScreenshots(
     [{ url: "https://example.com", name: "idle" }],
     "./out",
     { ...baseOptions, waitUntil: "networkidle0" }
   );
 
-  expect(mockGoto).toHaveBeenCalledWith("https://example.com", {
+  expect(goto).toHaveBeenCalledWith("https://example.com", {
     timeout: 5000,
     waitUntil: "networkidle0",
   });
 });
 
 test("respects custom viewport width", async () => {
+  const { setViewport } = await getMocks();
+
   await takeScreenshots(
     [{ url: "https://example.com", name: "wide" }],
     "./out",
     { ...baseOptions, viewportWidth: 1920 }
   );
 
-  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1920, height: 1080 });
+  expect(setViewport).toHaveBeenCalledWith({ width: 1920, height: 1080 });
 });
 
 test("runs multiple screenshots with concurrency", async () => {
+  const { newPage } = await getMocks();
   const items = [
     { url: "https://example.com", name: "page-one" },
     { url: "https://example.org", name: "page-two" },
@@ -104,13 +128,14 @@ test("runs multiple screenshots with concurrency", async () => {
 
   await takeScreenshots(items, "./out", { ...baseOptions, concurrency: 2 });
 
-  expect(mockNewPage).toHaveBeenCalledTimes(3);
-  expect(mockScreenshot).toHaveBeenCalledTimes(3);
-  expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+  // +1 because getMocks() itself calls newPage once
+  expect(newPage).toHaveBeenCalledTimes(items.length + 1);
+  expect(fs.writeFileSync).toHaveBeenCalledTimes(items.length);
 });
 
 test("retries on failure and succeeds on second attempt", async () => {
-  mockScreenshot
+  const { screenshot } = await getMocks();
+  screenshot
     .mockRejectedValueOnce(new Error("network error"))
     .mockResolvedValueOnce(Buffer.from("png-data"));
 
@@ -120,7 +145,8 @@ test("retries on failure and succeeds on second attempt", async () => {
     { ...baseOptions, retries: 2 }
   );
 
-  expect(mockScreenshot).toHaveBeenCalledTimes(2);
+  // +1 for the getMocks() call, then 2 real attempts
+  expect(screenshot).toHaveBeenCalledTimes(3);
   expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
 });
 

--- a/__tests__/screenshot.test.ts
+++ b/__tests__/screenshot.test.ts
@@ -128,7 +128,7 @@ test("runs multiple screenshots with concurrency", async () => {
 
   await takeScreenshots(items, "./out", { ...baseOptions, concurrency: 2 });
 
-  // +1 because getMocks() itself calls newPage once
+  // +1 because getMocks() itself calls newPage() once to get the page reference
   expect(newPage).toHaveBeenCalledTimes(items.length + 1);
   expect(fs.writeFileSync).toHaveBeenCalledTimes(items.length);
 });
@@ -145,8 +145,7 @@ test("retries on failure and succeeds on second attempt", async () => {
     { ...baseOptions, retries: 2 }
   );
 
-  // +1 for the getMocks() call, then 2 real attempts
-  expect(screenshot).toHaveBeenCalledTimes(3);
+  expect(screenshot).toHaveBeenCalledTimes(2); 
   expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
 });
 

--- a/__tests__/screenshot.test.ts
+++ b/__tests__/screenshot.test.ts
@@ -1,20 +1,144 @@
+import * as fs from "fs";
+import puppeteer from "puppeteer";
+import { takeScreenshots } from "../src/screenshot";
+
+// ── mock fs ──────────────────────────────────────────────────────────────────
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
+  existsSync: jest.fn().mockReturnValue(true),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}));
+
+// ── mock puppeteer ────────────────────────────────────────────────────────────
+const mockClose     = jest.fn();
+const mockScreenshot = jest.fn().mockResolvedValue(Buffer.from("png-data"));
+const mockGoto      = jest.fn();
+const mockSetViewport = jest.fn();
+const mockPageClose = jest.fn();
+const mockNewPage   = jest.fn().mockResolvedValue({
+  setViewport: mockSetViewport,
+  goto: mockGoto,
+  screenshot: mockScreenshot,
+  close: mockPageClose,
+});
+
 jest.mock("puppeteer", () => ({
   launch: jest.fn().mockResolvedValue({
-    newPage: jest.fn().mockResolvedValue({
-      goto: jest.fn(),
-      screenshot: jest.fn().mockResolvedValue(Buffer.from("")),
-      close: jest.fn(),
-    }),
-    close: jest.fn(),
+    newPage: mockNewPage,
+    close: mockClose,
   }),
 }));
 
-import { takeScreenshots } from "../src/screenshot";
+// ── shared base options ───────────────────────────────────────────────────────
+const baseOptions = {
+  concurrency: 1,
+  timeoutMs: 5000,
+  retries: 1,
+  waitUntil: "load" as const,
+  square: false,
+  viewportWidth: 1280,
+};
 
-test("runs screenshots", async () => {
-  await takeScreenshots([{ url: "https://example.com" }], "./out", {
-    concurrency: 1,
-    timeoutMs: 1000,
-    retries: 1,
+beforeEach(() => jest.clearAllMocks());
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+test("captures a screenshot with default options", async () => {
+  await takeScreenshots([{ url: "https://example.com", name: "homepage" }], "./out", baseOptions);
+
+  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 720 });
+  expect(mockGoto).toHaveBeenCalledWith("https://example.com", {
+    timeout: 5000,
+    waitUntil: "load",
   });
+  expect(mockScreenshot).toHaveBeenCalledWith({ fullPage: true });
+  expect(fs.writeFileSync).toHaveBeenCalledWith("out/homepage.png", expect.any(Buffer));
+  expect(mockPageClose).toHaveBeenCalled();
+  expect(mockClose).toHaveBeenCalled();
+});
+
+test("sets square viewport and clip when square is true", async () => {
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "square-shot" }],
+    "./out",
+    { ...baseOptions, square: true, viewportWidth: 1280 }
+  );
+
+  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 1280 });
+  expect(mockScreenshot).toHaveBeenCalledWith({
+    fullPage: false,
+    clip: { x: 0, y: 0, width: 1280, height: 1280 },
+  });
+});
+
+test("passes waitUntil to page.goto", async () => {
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "idle" }],
+    "./out",
+    { ...baseOptions, waitUntil: "networkidle0" }
+  );
+
+  expect(mockGoto).toHaveBeenCalledWith("https://example.com", {
+    timeout: 5000,
+    waitUntil: "networkidle0",
+  });
+});
+
+test("respects custom viewport width", async () => {
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "wide" }],
+    "./out",
+    { ...baseOptions, viewportWidth: 1920 }
+  );
+
+  expect(mockSetViewport).toHaveBeenCalledWith({ width: 1920, height: 1080 });
+});
+
+test("runs multiple screenshots with concurrency", async () => {
+  const items = [
+    { url: "https://example.com", name: "page-one" },
+    { url: "https://example.org", name: "page-two" },
+    { url: "https://example.net", name: "page-three" },
+  ];
+
+  await takeScreenshots(items, "./out", { ...baseOptions, concurrency: 2 });
+
+  expect(mockNewPage).toHaveBeenCalledTimes(3);
+  expect(mockScreenshot).toHaveBeenCalledTimes(3);
+  expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+});
+
+test("retries on failure and succeeds on second attempt", async () => {
+  mockScreenshot
+    .mockRejectedValueOnce(new Error("network error"))
+    .mockResolvedValueOnce(Buffer.from("png-data"));
+
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "flaky" }],
+    "./out",
+    { ...baseOptions, retries: 2 }
+  );
+
+  expect(mockScreenshot).toHaveBeenCalledTimes(2);
+  expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+});
+
+test("uses hashed filename when name is missing", async () => {
+  await takeScreenshots([{ url: "https://example.com" }], "./out", baseOptions);
+
+  const [[filePath]] = (fs.writeFileSync as jest.Mock).mock.calls;
+  expect(filePath).toMatch(/^out\/[a-f0-9]{64}\.png$/);
+});
+
+test("creates output directory if it does not exist", async () => {
+  (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
+
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "homepage" }],
+    "./out",
+    baseOptions
+  );
+
+  expect(fs.mkdirSync).toHaveBeenCalledWith("./out", { recursive: true });
 });

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,21 @@ inputs:
     required: false
     default: "2"
 
+  wait_until:
+    description: "Puppeteer page load event to wait for before capturing. Options: load, domcontentloaded, networkidle0, networkidle2"
+    required: false
+    default: "load"
+  
+  square:
+    description: "If true, captures a square screenshot by setting a square viewport and clipping to width x width"
+    required: false
+    default: "false"
+  
+  viewport_width:
+    description: "Viewport width in pixels. Also used as the square size when square is true."
+    required: false
+    default: "1280"
+
 runs:
   using: "docker"
   image: docker://ghcr.io/guibranco/github-screenshot-action:v2.0.16

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,9 @@ async function run() {
       concurrency: parseInt(core.getInput("concurrency")),
       timeoutMs: parseInt(core.getInput("timeout_ms")),
       retries: parseInt(core.getInput("retries")),
+      waitUntil: core.getInput("wait_until") as "load" | "domcontentloaded" | "networkidle0" | "networkidle2",
+      square: core.getInput("square") === "true",
+      viewportWidth: parseInt(core.getInput("viewport_width")),
     };
 
     const items = loadItems(jsonFile);

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -5,41 +5,74 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { log } from "./logger";
 
-export async function takeScreenshots(items: any[], outputDir: string, options: any) {
+interface ScreenshotOptions {
+  concurrency: number;
+  timeoutMs: number;
+  retries: number;
+  waitUntil: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+  square: boolean;
+  viewportWidth: number;
+}
+
+export async function takeScreenshots(items: any[], outputDir: string, options: ScreenshotOptions) {
   if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
 
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const limit = pLimit(options.concurrency);
 
   await Promise.all(
-    items.map((item) =>
-      limit(() => process(item, browser, outputDir, options))
-    )
+    items.map((item) => limit(() => capture(item, browser, outputDir, options)))
   );
 
   await browser.close();
 }
 
-async function process(item: any, browser: any, outputDir: string, options: any) {
+async function capture(item: any, browser: any, outputDir: string, options: ScreenshotOptions) {
   for (let i = 0; i <= options.retries; i++) {
     try {
       const page = await browser.newPage();
 
-      await page.goto(item.url, { timeout: options.timeoutMs });
+      // Set viewport — square uses width x width, otherwise a standard 16:9 height
+      const viewportHeight = options.square
+        ? options.viewportWidth
+        : Math.round(options.viewportWidth * (9 / 16));
+
+      await page.setViewport({
+        width: options.viewportWidth,
+        height: viewportHeight,
+      });
+
+      await page.goto(item.url, {
+        timeout: options.timeoutMs,
+        waitUntil: options.waitUntil,
+      });
 
       const name = (item.name || hash(item.url)).toLowerCase();
       const file = path.join(outputDir, `${name}.png`);
 
-      const buffer = await page.screenshot({ fullPage: true });
+      const screenshotOptions: any = { fullPage: !options.square };
 
+      if (options.square) {
+        screenshotOptions.clip = {
+          x: 0,
+          y: 0,
+          width: options.viewportWidth,
+          height: options.viewportWidth,
+        };
+      }
+
+      const buffer = await page.screenshot(screenshotOptions);
       fs.writeFileSync(file, buffer);
 
       await page.close();
+      log.success(`Captured ${item.url} → ${file}`);
       return;
-    } catch (e) {
-      log.warn(`Retry ${i} failed for ${item.url}`);
+    } catch (e: any) {
+      log.warn(`Retry ${i} failed for ${item.url}: ${e.message}`);
     }
   }
+
+  log.error(`All retries exhausted for ${item.url}`);
 }
 
 function hash(input: string) {


### PR DESCRIPTION
### **User description**
## 📑 Description
Add the option in the action to take square screenshots and also wait for the page load completely

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


___

### **Description**
- Added options to the action for capturing square screenshots and waiting for page load events.
- Introduced `wait_until` to specify Puppeteer page load events.
- Added `square` option to capture square screenshots.
- Included `viewport_width` to set viewport dimensions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Enhance action.yml with new screenshot options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

action.yml
<li>Added <code>wait_until</code> input for specifying Puppeteer page load events.<br> <li> Introduced <code>square</code> input for capturing square screenshots.<br> <li> Added <code>viewport_width</code> input for defining viewport width.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/github-screenshot-action/pull/44/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+15/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `wait_until` configuration option with support for DOM content load, full page load, and network idle states
  * Introduced `square` mode for capturing square-format screenshots
  * Added `viewport_width` parameter to customize screenshot dimensions
  
* **Documentation**
  * Updated usage examples with new configuration options and corresponding documentation sections on wait strategies and square mode behavior
  * Updated example workflow to latest action version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->