### PR TITLE
Change base image from node:26-slim to node:24-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y \
     chromium \


### PR DESCRIPTION
## 📑 Description
Change base image from node:26-slim to node:24-slim

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container base image to Node.js version 24.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/github-screenshot-action/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->