### PR TITLE
chore: add VSCode settings and downgrade Node to 24

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "sonarlint.connectedMode.project": {
+        "connectionId": "guibranco",
+        "projectKey": "guibranco_github-screenshot-action"
+    },
+    "snyk.advanced.autoSelectOrganization": true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y \
     chromium \


### PR DESCRIPTION
## 📑 Description
Add SonarLint and Snyk VSCode settings for project-level static analysis configuration, and downgrade the base Docker image from node:26-slim to node:24-slim for stability.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Align development environment and container base image with a stable Node 24 toolchain.

Enhancements:
- Downgrade the Docker base image from node:26-slim to node:24-slim for improved stability and compatibility.

Chores:
- Add project-level VSCode settings to support static analysis tools such as SonarLint and Snyk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code workspace configuration for development tools.

---

**Note:** This is an internal configuration change for development environments and does not affect end-user functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/github-screenshot-action/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->