### PR TITLE
feat: add waitAfterLoad delay and network idle wait +semver: minor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "connectionId": "guibranco",
         "projectKey": "guibranco_github-screenshot-action"
     },
-    "snyk.advanced.autoSelectOrganization": true
+    "snyk.advanced.autoSelectOrganization": true,
+    "sarif-viewer.connectToGithubCodeScanning": "on"
 }

--- a/__tests__/screenshot.test.ts
+++ b/__tests__/screenshot.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import puppeteer from "puppeteer";
 import { takeScreenshots } from "../src/screenshot";
 
@@ -16,11 +17,13 @@ jest.mock("puppeteer", () => {
   const mockScreenshot = jest.fn().mockResolvedValue(Buffer.from("png-data"));
   const mockGoto       = jest.fn();
   const mockSetViewport = jest.fn();
+  const mockWaitForNetworkIdle = jest.fn();
   const mockNewPage    = jest.fn().mockResolvedValue({
     setViewport: mockSetViewport,
     goto: mockGoto,
     screenshot: mockScreenshot,
     close: mockPageClose,
+    waitForNetworkIdle: mockWaitForNetworkIdle,
   });
   const mockBrowserClose = jest.fn();
 
@@ -37,13 +40,14 @@ const getMocks = async () => {
   const browser = await (puppeteer.launch as jest.Mock)();
   const page    = await browser.newPage();
   return {
-    launch:      puppeteer.launch as jest.Mock,
-    browserClose: browser.close as jest.Mock,
-    newPage:     browser.newPage as jest.Mock,
-    setViewport: page.setViewport as jest.Mock,
-    goto:        page.goto as jest.Mock,
-    screenshot:  page.screenshot as jest.Mock,
-    pageClose:   page.close as jest.Mock,
+    launch:               puppeteer.launch as jest.Mock,
+    browserClose:         browser.close as jest.Mock,
+    newPage:              browser.newPage as jest.Mock,
+    setViewport:          page.setViewport as jest.Mock,
+    goto:                 page.goto as jest.Mock,
+    screenshot:           page.screenshot as jest.Mock,
+    pageClose:            page.close as jest.Mock,
+    waitForNetworkIdle:   page.waitForNetworkIdle as jest.Mock,
   };
 };
 
@@ -55,6 +59,7 @@ const baseOptions = {
   waitUntil: "load" as const,
   square: false,
   viewportWidth: 1280,
+  waitAfterLoad: 0,
 };
 
 beforeEach(() => jest.clearAllMocks());
@@ -62,7 +67,7 @@ beforeEach(() => jest.clearAllMocks());
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 test("captures a screenshot with default options", async () => {
-  const { setViewport, goto, screenshot } = await getMocks();
+  const { setViewport, goto, screenshot, waitForNetworkIdle } = await getMocks();
 
   await takeScreenshots([{ url: "https://example.com", name: "homepage" }], "./out", baseOptions);
 
@@ -71,8 +76,9 @@ test("captures a screenshot with default options", async () => {
     timeout: 5000,
     waitUntil: "load",
   });
+  expect(waitForNetworkIdle).toHaveBeenCalledWith({ timeout: 5000 });
   expect(screenshot).toHaveBeenCalledWith({ fullPage: true });
-  expect(fs.writeFileSync).toHaveBeenCalledWith("out/homepage.png", expect.any(Buffer));
+  expect(fs.writeFileSync).toHaveBeenCalledWith(path.join("out", "homepage.png"), expect.any(Buffer));
 });
 
 test("sets square viewport and clip when square is true", async () => {
@@ -153,7 +159,7 @@ test("uses hashed filename when name is missing", async () => {
   await takeScreenshots([{ url: "https://example.com" }], "./out", baseOptions);
 
   const [[filePath]] = (fs.writeFileSync as jest.Mock).mock.calls;
-  expect(filePath).toMatch(/^out\/[a-f0-9]{64}\.png$/);
+  expect(filePath).toMatch(/[a-f0-9]{64}\.png$/);
 });
 
 test("creates output directory if it does not exist", async () => {
@@ -166,4 +172,58 @@ test("creates output directory if it does not exist", async () => {
   );
 
   expect(fs.mkdirSync).toHaveBeenCalledWith("./out", { recursive: true });
+});
+
+test("calls waitForNetworkIdle when waitUntil is domcontentloaded", async () => {
+  const { waitForNetworkIdle } = await getMocks();
+
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "dce" }],
+    "./out",
+    { ...baseOptions, waitUntil: "domcontentloaded" }
+  );
+
+  expect(waitForNetworkIdle).toHaveBeenCalledWith({ timeout: 5000 });
+});
+
+test("does not call waitForNetworkIdle when waitUntil is networkidle2", async () => {
+  const { waitForNetworkIdle } = await getMocks();
+
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "idle" }],
+    "./out",
+    { ...baseOptions, waitUntil: "networkidle2" }
+  );
+
+  expect(waitForNetworkIdle).not.toHaveBeenCalled();
+});
+
+test("does not call waitForNetworkIdle when waitUntil is networkidle0", async () => {
+  const { waitForNetworkIdle } = await getMocks();
+
+  await takeScreenshots(
+    [{ url: "https://example.com", name: "idle0" }],
+    "./out",
+    { ...baseOptions, waitUntil: "networkidle0" }
+  );
+
+  expect(waitForNetworkIdle).not.toHaveBeenCalled();
+});
+
+test("waits extra delay when waitAfterLoad is set", async () => {
+  jest.useFakeTimers();
+  const { screenshot } = await getMocks();
+
+  const promise = takeScreenshots(
+    [{ url: "https://example.com", name: "delayed" }],
+    "./out",
+    // networkidle2 skips waitForNetworkIdle so only the setTimeout is pending
+    { ...baseOptions, waitUntil: "networkidle2", waitAfterLoad: 2000 }
+  );
+
+  await jest.runAllTimersAsync();
+  await promise;
+
+  expect(screenshot).toHaveBeenCalled();
+  jest.useRealTimers();
 });

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,12 @@ inputs:
   wait_until:
     description: "Puppeteer page load event to wait for before capturing. Options: load, domcontentloaded, networkidle0, networkidle2"
     required: false
-    default: "load"
+    default: "networkidle2"
+
+  wait_after_load:
+    description: "Extra milliseconds to wait after the page load event. Useful for React/Vite apps that animate or fetch data lazily after hydration."
+    required: false
+    default: "0"
   
   square:
     description: "If true, captures a square screenshot by setting a square viewport and clipping to width x width"

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function run() {
       waitUntil: core.getInput("wait_until") as "load" | "domcontentloaded" | "networkidle0" | "networkidle2",
       square: core.getInput("square") === "true",
       viewportWidth: parseInt(core.getInput("viewport_width")),
+      waitAfterLoad: parseInt(core.getInput("wait_after_load") || "0"),
     };
 
     const items = loadItems(jsonFile);

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -12,6 +12,7 @@ interface ScreenshotOptions {
   waitUntil: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
   square: boolean;
   viewportWidth: number;
+  waitAfterLoad: number;
 }
 
 export async function takeScreenshots(items: any[], outputDir: string, options: ScreenshotOptions) {
@@ -46,6 +47,15 @@ async function capture(item: any, browser: any, outputDir: string, options: Scre
         timeout: options.timeoutMs,
         waitUntil: options.waitUntil,
       });
+
+      // React/Vite SPAs render after the load event — wait for network to settle
+      if (options.waitUntil === "load" || options.waitUntil === "domcontentloaded") {
+        await page.waitForNetworkIdle({ timeout: options.timeoutMs });
+      }
+
+      if (options.waitAfterLoad > 0) {
+        await new Promise<void>(resolve => setTimeout(resolve, options.waitAfterLoad));
+      }
 
       const name = (item.name || hash(item.url)).toLowerCase();
       const file = path.join(outputDir, `${name}.png`);


### PR DESCRIPTION
## 📑 Description
Add `wait_after_load` input (ms) for extra delay after page load, useful for SPAs that hydrate lazily. Also call
`waitForNetworkIdle` automatically when `waitUntil` is `load` or `domcontentloaded` to capture fully-rendered pages. Default `wait_until` changed from `load` to `networkidle2`.

Update tests to cover new behaviour and use `path.join` for cross-platform path assertions. Enable SARIF viewer GitHub Code Scanning integration in VS Code settings.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wait_after_load` input parameter for configurable delay after page load before capturing screenshots.
  * Updated default page load strategy to `networkidle2` for improved screenshot reliability.

* **Chores**
  * Updated VS Code settings for security scanning integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/github-screenshot-action/pull/91)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->