### PR TITLE
ci: add Docker matrix builds for multiple Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,8 @@ jobs:
           actual=$(docker run --rm --entrypoint sh screenshot-action-${{ matrix.node_version }} -c "echo \$PUPPETEER_EXECUTABLE_PATH")
           echo "PUPPETEER_EXECUTABLE_PATH: $actual"
           [ "$actual" = "/usr/bin/chromium" ] || { echo "Unexpected value: $actual"; exit 1; }
+
+      - name: Verify @actions/core loads (catches ERR_PACKAGE_PATH_NOT_EXPORTED on Node 26+)
+        run: |
+          docker run --rm --entrypoint node screenshot-action-${{ matrix.node_version }} \
+            -e "require('@actions/core'); console.log('OK')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,38 @@ jobs:
       - run: npm run build
       - run: npm test
 
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [22, 24, 26]
+      fail-fast: false
+
+    name: Docker (node:${{ matrix.node_version }}-slim)
+
+    steps:
+      - uses: actions/checkout@v6
+
       - name: Build Docker image
-        run: docker build -t screenshot-action .
+        run: docker build --build-arg NODE_VERSION=${{ matrix.node_version }} -t screenshot-action-${{ matrix.node_version }} .
+
+      - name: Verify Node.js major version
+        run: |
+          actual=$(docker run --rm --entrypoint node screenshot-action-${{ matrix.node_version }} --version)
+          echo "Node version: $actual"
+          echo "$actual" | grep -q "^v${{ matrix.node_version }}\." || { echo "Expected v${{ matrix.node_version }}.x, got $actual"; exit 1; }
+
+      - name: Verify Chromium is installed and executable
+        run: docker run --rm --entrypoint chromium screenshot-action-${{ matrix.node_version }} --version
+
+      - name: Verify compiled dist files exist
+        run: docker run --rm --entrypoint ls screenshot-action-${{ matrix.node_version }} /app/dist/main.js
+
+      - name: Verify entrypoint is executable
+        run: docker run --rm --entrypoint sh screenshot-action-${{ matrix.node_version }} -c "test -x /app/entrypoint.sh && echo 'entrypoint OK'"
+
+      - name: Verify PUPPETEER_EXECUTABLE_PATH env var
+        run: |
+          actual=$(docker run --rm --entrypoint sh screenshot-action-${{ matrix.node_version }} -c "echo \$PUPPETEER_EXECUTABLE_PATH")
+          echo "PUPPETEER_EXECUTABLE_PATH: $actual"
+          [ "$actual" = "/usr/bin/chromium" ] || { echo "Unexpected value: $actual"; exit 1; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:24-slim
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim
 
 RUN apt-get update && apt-get install -y \
     chromium \


### PR DESCRIPTION
## 📑 Description
Introduce a new Docker job in the CI workflow that builds Docker images for multiple Node.js versions (22, 24, 26) using a matrix strategy. This ensures compatibility across different Node.js environments and helps catch potential issues early.

Update the Dockerfile to use an argument for the Node.js version (NODE_VERSION) to facilitate the version change in the build process. This allows the Docker image to build with the appropriate Node.js version specified in the matrix setup.

Add several verification steps in the CI workflow to ensure the Docker image is built correctly. These checks confirm:
- The Node.js major version used matches the one specified.
- Chromium is installed and executable.
- Compiled dist files exist.
- The entrypoint script is executable.
- The PUPPETEER_EXECUTABLE_PATH is set correctly.

These changes improve the robustness of the CI pipeline by enabling testing across multiple environments, thereby increasing confidence in the deployment process.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a CI Docker job that builds and verifies images across multiple Node.js versions using a matrix strategy.

Build:
- Make Dockerfile configurable via a NODE_VERSION build argument to support building images for different Node.js versions.

CI:
- Introduce a matrix-based Docker job in the CI workflow to build images for Node.js 22, 24, and 26 and verify runtime environment, Chromium availability, built artifacts, entrypoint executability, and Puppeteer configuration.